### PR TITLE
treat '/foo' as 'foo'

### DIFF
--- a/jqfpy/accessor.py
+++ b/jqfpy/accessor.py
@@ -1,7 +1,7 @@
 # todo: strict version
 class Accessor:
     def split_key(self, k, *, sep="/"):
-        return [normalize_json_pointer(x) for x in k.split(sep)]
+        return [normalize_json_pointer(x) for x in k.lstrip(sep).split(sep)]
 
     def split_key_pair(self, k, *, sep="@"):
         if sep not in k:

--- a/jqfpy/tests/test_get.py
+++ b/jqfpy/tests/test_get.py
@@ -18,6 +18,7 @@ class GetTests(unittest.TestCase):
         target = self._makeOne(d)
 
         candidates = [
+            ("/person", d["person"]),
             ("person", d["person"]),
             ("person/name", "foo"),
             ("person/age", 20),


### PR DESCRIPTION
fix #26

after this PR, cannot access the data that "" is key.

```json
{
"": {"x": "y"}
}
```